### PR TITLE
Fixes an error in substituting the current end date of an event in release-v.2.6.x

### DIFF
--- a/Calendar/pages/event_update_page.php
+++ b/Calendar/pages/event_update_page.php
@@ -185,7 +185,7 @@ layout_page_begin();
 
                                         <?php
                                         if( array_key_exists( 'UNTIL', $t_rule ) ) {
-                                            $t_time_until = $t_rule['UNTIL']->format( config_get( 'short_date_format' ) );
+                                            $t_time_until = $t_rule['UNTIL']->format( plugin_config_get( 'short_date_format' ) );
                                         } else {
                                             $t_time_until = plugin_lang_get( 'never_ending_repetition' );
                                         }


### PR DESCRIPTION
Fixes an error in substituting the current end date of an event repetition into the mini-calendar when editing an event.
Fix #71 